### PR TITLE
fix: odd number grid items fix for consistent styling

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -38,7 +38,6 @@ const styles = StyleSheet.create({
     backgroundColor: '#adadad',
   },
   requiredContentBox: {
-    flex: 1,
     aspectRatio: 1,
   },
   contentBoxSelected: {


### PR DESCRIPTION
fixes this #2 


<img width="360" alt="image" src="https://github.com/christerence/react-native-interactive-grid/assets/30540602/23a16dae-b477-4695-b862-4fe43f30132b">
