### PR TITLE
fix: error with dependency on selectIds rather than block level ids

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -74,11 +74,11 @@ export function InteractiveGrid({
         if (existingIndex >= 0) {
           ids.splice(existingIndex, 1);
         } else {
-          if (selectedIds.length < maxSelect) {
+          if (ids.length < maxSelect) {
             ids.push(gridItemId);
           }
         }
-        onSelect(selectedIds);
+        onSelect(ids);
         return [...ids];
       });
     },


### PR DESCRIPTION
Fixes this issue #6, which is caused by using selectIds within the state instead of block level within the setSelect